### PR TITLE
Add automatic semester detection for marks/exam

### DIFF
--- a/vitap_vtop_client/client.py
+++ b/vitap_vtop_client/client.py
@@ -21,7 +21,7 @@ from .login import (
     LoggedInStudent,
 )
 
-from .utils import solve_captcha
+from .utils import solve_captcha, fetch_current_sem_sub_id
 
 from .attendance import fetch_attendance, AttendanceModel
 from .biometric import fetch_biometric, BiometricModel
@@ -84,6 +84,7 @@ class VtopClient:
         self.max_login_retries = max_login_retries
         self.captcha_retries = captcha_retries
         self._login_lock = asyncio.Lock()  # Prevents concurrent login attempts
+        self._current_sem_sub_id: str | None = None
 
     async def _perform_login_sequence(self) -> LoggedInStudent:
         """
@@ -167,6 +168,19 @@ class VtopClient:
         # Check if already logged in and session is potentially valid
         if self._logged_in_student is not None:
             return self._logged_in_student
+
+    async def _get_current_sem_sub_id(self) -> str:
+        """Fetch and cache the current semesterSubId from VTOP."""
+        if self._current_sem_sub_id:
+            return self._current_sem_sub_id
+        logged_in_info = await self._ensure_logged_in()
+        sem_sub_id = await fetch_current_sem_sub_id(
+            client=self._client,
+            registration_number=logged_in_info.registration_number,
+            csrf_token=logged_in_info.post_login_csrf_token,
+        )
+        self._current_sem_sub_id = sem_sub_id
+        return sem_sub_id
 
         async with self._login_lock:
             # Double-check after acquiring the lock, in case another coroutine logged in
@@ -280,7 +294,7 @@ class VtopClient:
             csrf_token=logged_in_info.post_login_csrf_token,
         )
 
-    async def get_exam_schedule(self, sem_sub_id: str) -> ExamScheduleModel:
+    async def get_exam_schedule(self, sem_sub_id: str | None = None) -> ExamScheduleModel:
         """
         Fetches all exam schedules for the given semester.
 
@@ -288,6 +302,7 @@ class VtopClient:
             A ExamScheduleModel containing the parsed exam schedule details.
         """
         logged_in_info = await self._ensure_logged_in()
+        sem_sub_id = sem_sub_id or await self._get_current_sem_sub_id()
         return await fetch_exam_schedule(
             client=self._client,
             registration_number=logged_in_info.registration_number,
@@ -295,7 +310,7 @@ class VtopClient:
             semSubID=sem_sub_id,
         )
 
-    async def get_marks(self, sem_sub_id: str) -> MarksModel:
+    async def get_marks(self, sem_sub_id: str | None = None) -> MarksModel:
         """
         Fetches all marks for the given semester.
 
@@ -303,6 +318,7 @@ class VtopClient:
             A MarksModel containing the parsed mark details.
         """
         logged_in_info = await self._ensure_logged_in()
+        sem_sub_id = sem_sub_id or await self._get_current_sem_sub_id()
         return await fetch_marks(
             client=self._client,
             registration_number=logged_in_info.registration_number,

--- a/vitap_vtop_client/utils/__init__.py
+++ b/vitap_vtop_client/utils/__init__.py
@@ -2,3 +2,5 @@ from .solve_captcha import solve_captcha
 from .find_csrf import find_csrf
 from .find_login_response import login_error_identifier
 from .extract_student_pfp import extract_pfp_base64
+from .fetch_current_semester import fetch_current_sem_sub_id
+

--- a/vitap_vtop_client/utils/fetch_current_semester.py
+++ b/vitap_vtop_client/utils/fetch_current_semester.py
@@ -1,0 +1,30 @@
+import time
+import httpx
+from vitap_vtop_client.constants import MARKS_URL, HEADERS
+from vitap_vtop_client.utils.find_current_semester import find_current_sem_sub_id
+from vitap_vtop_client.exceptions.exception import VtopConnectionError, VtopSessionError
+
+
+async def fetch_current_sem_sub_id(
+    client: httpx.AsyncClient,
+    registration_number: str,
+    csrf_token: str,
+) -> str:
+    """Retrieve the current semesterSubId using the marks page."""
+    try:
+        init_data = {
+            "verifyMenu": "true",
+            "authorizedID": registration_number,
+            "_csrf": csrf_token,
+            "nocache": int(round(time.time() * 1000)),
+        }
+        response = await client.post(MARKS_URL, data=init_data, headers=HEADERS)
+        response.raise_for_status()
+        sem = find_current_sem_sub_id(response.text)
+        if not sem:
+            raise VtopSessionError("Unable to determine current semester")
+        return sem
+    except httpx.RequestError as e:
+        raise VtopConnectionError(
+            f"Failed to determine current semester: {e}", original_exception=e, status_code=502
+        )

--- a/vitap_vtop_client/utils/find_current_semester.py
+++ b/vitap_vtop_client/utils/find_current_semester.py
@@ -1,0 +1,20 @@
+from bs4 import BeautifulSoup
+
+
+def find_current_sem_sub_id(html: str) -> str | None:
+    """Parse semesterSubId from a page containing a semester select."""
+    soup = BeautifulSoup(html, 'html.parser')
+
+    select = soup.find('select', attrs={'name': 'semesterSubId'})
+    if select:
+        option = select.find('option', selected=True)
+        if option and option.get('value'):
+            return option['value']
+        first_option = select.find('option')
+        if first_option and first_option.get('value'):
+            return first_option['value']
+
+    input_el = soup.find('input', attrs={'name': 'semesterSubId'})
+    if input_el and input_el.get('value'):
+        return input_el['value']
+    return None


### PR DESCRIPTION
## Summary
- provide utility to parse the current semester from HTML
- retrieve current semester via marks page
- expose semester utilities
- update client to fetch exam schedule and marks without explicit semester

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68626d0f88f4832fbaff240b34de9248