### PR TITLE
Add CLI for exam info

### DIFF
--- a/vitap_vtop_client/__init__.py
+++ b/vitap_vtop_client/__init__.py
@@ -1,2 +1,46 @@
+"""Convenience exports for the vitap_vtop_client package."""
+
 from .client import VtopClient
-from .exceptions import exception
+from .exceptions import (
+    VitapVtopClientError,
+    VtopConnectionError,
+    VtopCaptchaError,
+    VtopCaptchaSolvingError,
+    VtopCsrfError,
+    VtopLoginError,
+    VtopSessionError,
+    VtopParsingError,
+    VtopAttendanceError,
+    VtopTimetableError,
+    VtopMentorError,
+    VtopBiometricError,
+    VtopGradeHistoryError,
+    VtopProfileError,
+    VtopExamScheduleError,
+    VtopMarksError,
+    VtopGeneralOutingError,
+    VtopWeekendOutingError,
+)
+
+__all__ = [
+    "VtopClient",
+    "VitapVtopClientError",
+    "VtopConnectionError",
+    "VtopCaptchaError",
+    "VtopCaptchaSolvingError",
+    "VtopCsrfError",
+    "VtopLoginError",
+    "VtopSessionError",
+    "VtopParsingError",
+    "VtopAttendanceError",
+    "VtopTimetableError",
+    "VtopMentorError",
+    "VtopBiometricError",
+    "VtopGradeHistoryError",
+    "VtopProfileError",
+    "VtopExamScheduleError",
+    "VtopMarksError",
+    "VtopGeneralOutingError",
+    "VtopWeekendOutingError",
+]
+

--- a/vitap_vtop_client/client.py
+++ b/vitap_vtop_client/client.py
@@ -21,7 +21,7 @@ from .login import (
     LoggedInStudent,
 )
 
-from .utils import solve_captcha
+from .utils import solve_captcha, fetch_current_sem_sub_id
 
 from .attendance import fetch_attendance, AttendanceModel
 from .biometric import fetch_biometric, BiometricModel
@@ -84,6 +84,7 @@ class VtopClient:
         self.max_login_retries = max_login_retries
         self.captcha_retries = captcha_retries
         self._login_lock = asyncio.Lock()  # Prevents concurrent login attempts
+        self._current_sem_sub_id: str | None = None
 
     async def _perform_login_sequence(self) -> LoggedInStudent:
         """
@@ -160,29 +161,41 @@ class VtopClient:
         )
 
     async def _ensure_logged_in(self) -> LoggedInStudent:
-        """
-        Ensures the client is logged in. If not, performs login.
-        This method is idempotent.
-        """
-        # Check if already logged in and session is potentially valid
+        """Ensure the client has a valid logged in session."""
         if self._logged_in_student is not None:
             return self._logged_in_student
 
         async with self._login_lock:
-            # Double-check after acquiring the lock, in case another coroutine logged in
             if self._logged_in_student is None:
                 print(
                     f"VtopClient: Not logged in or session expired for {self.username[:5]}****. Initiating login."
                 )
                 await self._perform_login_sequence()
 
-            if (
-                self._logged_in_student is None
-            ):  # Should be set by _perform_login_sequence on success
+            if self._logged_in_student is None:
                 raise VitapVtopClientError(
                     "VtopClient: Failed to establish a login session."
                 )
+
             return self._logged_in_student
+
+    async def _get_current_sem_sub_id(self) -> str:
+        """Fetch and cache the current semesterSubId from VTOP."""
+        if self._current_sem_sub_id:
+            return self._current_sem_sub_id
+
+        logged_in_info = await self._ensure_logged_in()
+        sem_sub_id = await fetch_current_sem_sub_id(
+            client=self._client,
+            registration_number=logged_in_info.registration_number,
+            csrf_token=logged_in_info.post_login_csrf_token,
+        )
+        self._current_sem_sub_id = sem_sub_id
+        return sem_sub_id
+
+    async def get_current_sem_sub_id(self) -> str:
+        """Public wrapper to retrieve the active semesterSubId."""
+        return await self._get_current_sem_sub_id()
 
     async def get_attendance(self, sem_sub_id: str) -> list[AttendanceModel]:
         """
@@ -280,7 +293,7 @@ class VtopClient:
             csrf_token=logged_in_info.post_login_csrf_token,
         )
 
-    async def get_exam_schedule(self, sem_sub_id: str) -> ExamScheduleModel:
+    async def get_exam_schedule(self, sem_sub_id: str | None = None) -> ExamScheduleModel:
         """
         Fetches all exam schedules for the given semester.
 
@@ -288,6 +301,7 @@ class VtopClient:
             A ExamScheduleModel containing the parsed exam schedule details.
         """
         logged_in_info = await self._ensure_logged_in()
+        sem_sub_id = sem_sub_id or await self._get_current_sem_sub_id()
         return await fetch_exam_schedule(
             client=self._client,
             registration_number=logged_in_info.registration_number,
@@ -295,7 +309,7 @@ class VtopClient:
             semSubID=sem_sub_id,
         )
 
-    async def get_marks(self, sem_sub_id: str) -> MarksModel:
+    async def get_marks(self, sem_sub_id: str | None = None) -> MarksModel:
         """
         Fetches all marks for the given semester.
 
@@ -303,6 +317,7 @@ class VtopClient:
             A MarksModel containing the parsed mark details.
         """
         logged_in_info = await self._ensure_logged_in()
+        sem_sub_id = sem_sub_id or await self._get_current_sem_sub_id()
         return await fetch_marks(
             client=self._client,
             registration_number=logged_in_info.registration_number,

--- a/vitap_vtop_client/exam_schedule/__init__.py
+++ b/vitap_vtop_client/exam_schedule/__init__.py
@@ -1,2 +1,6 @@
+"""Exports for the exam_schedule submodule."""
+
 from .exam_schedule import fetch_exam_schedule
 from .model.exam_schedule_model import ExamScheduleModel
+
+__all__ = ["fetch_exam_schedule", "ExamScheduleModel"]

--- a/vitap_vtop_client/exceptions/__init__.py
+++ b/vitap_vtop_client/exceptions/__init__.py
@@ -12,5 +12,30 @@ from .exception import (
     VtopTimetableError,
     VtopMentorError,
     VtopGradeHistoryError,
-    VtopProfileError
+    VtopProfileError,
+    VtopExamScheduleError,
+    VtopMarksError,
+    VtopGeneralOutingError,
+    VtopWeekendOutingError,
 )
+
+__all__ = [
+    "VitapVtopClientError",
+    "VtopConnectionError",
+    "VtopCaptchaError",
+    "VtopCaptchaSolvingError",
+    "VtopCsrfError",
+    "VtopLoginError",
+    "VtopSessionError",
+    "VtopParsingError",
+    "VtopAttendanceError",
+    "VtopBiometricError",
+    "VtopTimetableError",
+    "VtopMentorError",
+    "VtopGradeHistoryError",
+    "VtopProfileError",
+    "VtopExamScheduleError",
+    "VtopMarksError",
+    "VtopGeneralOutingError",
+    "VtopWeekendOutingError",
+]

--- a/vitap_vtop_client/marks/__init__.py
+++ b/vitap_vtop_client/marks/__init__.py
@@ -1,2 +1,6 @@
+"""Exports for the marks submodule."""
+
 from .marks import fetch_marks
 from .model.marks_model import MarksModel
+
+__all__ = ["fetch_marks", "MarksModel"]

--- a/vitap_vtop_client/utils/__init__.py
+++ b/vitap_vtop_client/utils/__init__.py
@@ -2,3 +2,6 @@ from .solve_captcha import solve_captcha
 from .find_csrf import find_csrf
 from .find_login_response import login_error_identifier
 from .extract_student_pfp import extract_pfp_base64
+from .fetch_current_semester import fetch_current_sem_sub_id
+from .sem_sub_id_helpers import get_semester_name
+

--- a/vitap_vtop_client/utils/fetch_current_semester.py
+++ b/vitap_vtop_client/utils/fetch_current_semester.py
@@ -1,0 +1,30 @@
+import time
+import httpx
+from vitap_vtop_client.constants import MARKS_URL, HEADERS
+from vitap_vtop_client.utils.find_current_semester import find_current_sem_sub_id
+from vitap_vtop_client.exceptions.exception import VtopConnectionError, VtopSessionError
+
+
+async def fetch_current_sem_sub_id(
+    client: httpx.AsyncClient,
+    registration_number: str,
+    csrf_token: str,
+) -> str:
+    """Retrieve the current semesterSubId using the marks page."""
+    try:
+        init_data = {
+            "verifyMenu": "true",
+            "authorizedID": registration_number,
+            "_csrf": csrf_token,
+            "nocache": int(round(time.time() * 1000)),
+        }
+        response = await client.post(MARKS_URL, data=init_data, headers=HEADERS)
+        response.raise_for_status()
+        sem = find_current_sem_sub_id(response.text)
+        if not sem:
+            raise VtopSessionError("Unable to determine current semester")
+        return sem
+    except httpx.RequestError as e:
+        raise VtopConnectionError(
+            f"Failed to determine current semester: {e}", original_exception=e, status_code=502
+        )

--- a/vitap_vtop_client/utils/find_current_semester.py
+++ b/vitap_vtop_client/utils/find_current_semester.py
@@ -1,0 +1,25 @@
+from bs4 import BeautifulSoup
+
+
+def find_current_sem_sub_id(html: str) -> str | None:
+    """Parse semesterSubId from a page containing a semester select."""
+    soup = BeautifulSoup(html, 'html.parser')
+
+    select = soup.find('select', attrs={"name": "semesterSubId"})
+    if select:
+        option = select.find("option", selected=True)
+        if option and option.get("value"):
+            value = option["value"].strip()
+            if value:
+                return value
+
+        for opt in select.find_all("option"):
+            value = opt.get("value", "").strip()
+            if value:
+                return value
+
+    input_el = soup.find('input', attrs={'name': 'semesterSubId'})
+    if input_el and input_el.get('value'):
+        return input_el['value']
+    return None
+

--- a/vitap_vtop_client/utils/sem_sub_id_helpers.py
+++ b/vitap_vtop_client/utils/sem_sub_id_helpers.py
@@ -1,0 +1,9 @@
+from vitap_vtop_client.constants import SemSubID
+
+
+def get_semester_name(sem_sub_id: str) -> str | None:
+    """Return the human readable name for a semesterSubId if known."""
+    for name, value in SemSubID.items():
+        if value == sem_sub_id:
+            return name
+    return None


### PR DESCRIPTION
## Summary
- support exam schedule and marks retrieval from command line
- expose new `get_current_sem_sub_id` helper on the client
- export all exceptions and fix module exports
- show active semester when running `profile` or `current_semester`
- handle blank placeholder option when detecting current semester

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m vitap_vtop_client --help | head -n 20`
- `python -m vitap_vtop_client 24BES7016 current_semester --password wrong | head -n 20` *(fails: invalid credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68626d0f88f4832fbaff240b34de9248