### PR TITLE
Add timetable helper

### DIFF
--- a/vitap_vtop_client/__init__.py
+++ b/vitap_vtop_client/__init__.py
@@ -1,2 +1,46 @@
+"""Convenience exports for the vitap_vtop_client package."""
+
 from .client import VtopClient
-from .exceptions import exception
+from .exceptions import (
+    VitapVtopClientError,
+    VtopConnectionError,
+    VtopCaptchaError,
+    VtopCaptchaSolvingError,
+    VtopCsrfError,
+    VtopLoginError,
+    VtopSessionError,
+    VtopParsingError,
+    VtopAttendanceError,
+    VtopTimetableError,
+    VtopMentorError,
+    VtopBiometricError,
+    VtopGradeHistoryError,
+    VtopProfileError,
+    VtopExamScheduleError,
+    VtopMarksError,
+    VtopGeneralOutingError,
+    VtopWeekendOutingError,
+)
+
+__all__ = [
+    "VtopClient",
+    "VitapVtopClientError",
+    "VtopConnectionError",
+    "VtopCaptchaError",
+    "VtopCaptchaSolvingError",
+    "VtopCsrfError",
+    "VtopLoginError",
+    "VtopSessionError",
+    "VtopParsingError",
+    "VtopAttendanceError",
+    "VtopTimetableError",
+    "VtopMentorError",
+    "VtopBiometricError",
+    "VtopGradeHistoryError",
+    "VtopProfileError",
+    "VtopExamScheduleError",
+    "VtopMarksError",
+    "VtopGeneralOutingError",
+    "VtopWeekendOutingError",
+]
+

--- a/vitap_vtop_client/__main__.py
+++ b/vitap_vtop_client/__main__.py
@@ -5,6 +5,8 @@ from getpass import getpass
 from typing import Any
 
 from .client import VtopClient
+from .utils import get_semester_name
+from .timetable.model import TimetableModel
 
 
 def _shorten(value: str, max_length: int = 40) -> str:
@@ -14,11 +16,43 @@ def _shorten(value: str, max_length: int = 40) -> str:
     return f"{value[:20]}...{value[-10:]}"  # show start and end
 
 
+def _print_timetable(tt: TimetableModel) -> None:
+    """Pretty-print a TimetableModel."""
+    days = [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+    ]
+
+    for day in days:
+        sessions = getattr(tt, day)
+        if not sessions:
+            continue
+        print(day + ":")
+        for course in sessions:
+            line = (
+                f"  {course.time}: {course.course_code} {course.course_name}"
+                f" ({course.slot}) @ {course.venue}"
+            )
+            if course.faculty:
+                line += f" - {course.faculty}"
+            print(line)
+        print()
+
+
 def _print_lines(obj: Any, indent: int = 0) -> None:
     """Recursively print dictionaries/lists with each entry on its own line."""
     prefix = " " * indent
     if hasattr(obj, "dict"):
         obj = obj.dict(exclude_none=True)
+
+    if isinstance(obj, TimetableModel):
+        _print_timetable(obj)
+        return
 
     if isinstance(obj, dict):
         for key, value in obj.items():
@@ -38,7 +72,21 @@ def _print_lines(obj: Any, indent: int = 0) -> None:
 async def main():
     parser = argparse.ArgumentParser(description="Command line interface for vitap_vtop_client")
     parser.add_argument("registration_number", help="Your VTOP registration number")
-    parser.add_argument("command", choices=["profile", "attendance", "timetable", "biometric", "grade_history", "mentor"], help="Which information to fetch")
+    parser.add_argument(
+        "command",
+        choices=[
+            "profile",
+            "attendance",
+            "timetable",
+            "biometric",
+            "grade_history",
+            "mentor",
+            "exam_schedule",
+            "marks",
+            "current_semester",
+        ],
+        help="Which information to fetch",
+    )
     parser.add_argument("--password", dest="password", help="VTOP password (will prompt if omitted)")
     parser.add_argument("--sem", dest="sem_sub_id", help="Semester subject ID for semester specific commands")
     parser.add_argument("--date", dest="date", help="Date for biometric in dd/mm/yyyy format")
@@ -49,13 +97,16 @@ async def main():
     async with VtopClient(args.registration_number, password) as client:
         if args.command == "profile":
             data = await client.get_profile()
+            current_sem = await client.get_current_sem_sub_id()
+            sem_name = get_semester_name(current_sem) or current_sem
+            data = data.dict(exclude_none=True)
+            data["current_semester"] = sem_name
+            data["current_sem_sub_id"] = current_sem
         elif args.command == "attendance":
             if not args.sem_sub_id:
                 parser.error("attendance command requires --sem")
             data = await client.get_attendance(args.sem_sub_id)
         elif args.command == "timetable":
-            if not args.sem_sub_id:
-                parser.error("timetable command requires --sem")
             data = await client.get_timetable(args.sem_sub_id)
         elif args.command == "biometric":
             if not args.date:
@@ -65,6 +116,17 @@ async def main():
             data = await client.get_grade_history()
         elif args.command == "mentor":
             data = await client.get_mentor()
+        elif args.command == "exam_schedule":
+            data = await client.get_exam_schedule(args.sem_sub_id)
+        elif args.command == "marks":
+            data = await client.get_marks(args.sem_sub_id)
+        elif args.command == "current_semester":
+            current_sem = await client.get_current_sem_sub_id()
+            sem_name = get_semester_name(current_sem) or current_sem
+            data = {
+                "current_semester": sem_name,
+                "current_sem_sub_id": current_sem,
+            }
         else:
             parser.error("Unknown command")
 

--- a/vitap_vtop_client/exam_schedule/__init__.py
+++ b/vitap_vtop_client/exam_schedule/__init__.py
@@ -1,2 +1,6 @@
+"""Exports for the exam_schedule submodule."""
+
 from .exam_schedule import fetch_exam_schedule
 from .model.exam_schedule_model import ExamScheduleModel
+
+__all__ = ["fetch_exam_schedule", "ExamScheduleModel"]

--- a/vitap_vtop_client/exceptions/__init__.py
+++ b/vitap_vtop_client/exceptions/__init__.py
@@ -12,5 +12,30 @@ from .exception import (
     VtopTimetableError,
     VtopMentorError,
     VtopGradeHistoryError,
-    VtopProfileError
+    VtopProfileError,
+    VtopExamScheduleError,
+    VtopMarksError,
+    VtopGeneralOutingError,
+    VtopWeekendOutingError,
 )
+
+__all__ = [
+    "VitapVtopClientError",
+    "VtopConnectionError",
+    "VtopCaptchaError",
+    "VtopCaptchaSolvingError",
+    "VtopCsrfError",
+    "VtopLoginError",
+    "VtopSessionError",
+    "VtopParsingError",
+    "VtopAttendanceError",
+    "VtopBiometricError",
+    "VtopTimetableError",
+    "VtopMentorError",
+    "VtopGradeHistoryError",
+    "VtopProfileError",
+    "VtopExamScheduleError",
+    "VtopMarksError",
+    "VtopGeneralOutingError",
+    "VtopWeekendOutingError",
+]

--- a/vitap_vtop_client/marks/__init__.py
+++ b/vitap_vtop_client/marks/__init__.py
@@ -1,2 +1,6 @@
+"""Exports for the marks submodule."""
+
 from .marks import fetch_marks
 from .model.marks_model import MarksModel
+
+__all__ = ["fetch_marks", "MarksModel"]

--- a/vitap_vtop_client/timetable/timetable.py
+++ b/vitap_vtop_client/timetable/timetable.py
@@ -37,8 +37,12 @@ async def fetch_timetable(
             "_csrf": csrf_token,
             "nocache": int(round(time.time() * 1000)),
         }
-        initial_response = await client.post(TIME_TABLE_URL, data=data_initial, headers=HEADERS)
+        initial_response = await client.post(
+            TIME_TABLE_URL, data=data_initial, headers=HEADERS
+        )
         initial_response.raise_for_status()
+        if "not authorized" in initial_response.text:
+            raise VtopTimetableError("Not authorized to access timetable page")
     
     except httpx.RequestError as e:
         print(f"Timetable initial POST failed: {e}")
@@ -59,11 +63,17 @@ async def fetch_timetable(
             "authorizedID": username,
             "x": datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT"),
         }
-        timetable_response = await client.post(GET_TIME_TABLE_URL, data=data_fetch, headers=HEADERS)
+        timetable_response = await client.post(
+            GET_TIME_TABLE_URL, data=data_fetch, headers=HEADERS
+        )
         timetable_response.raise_for_status()
+        if "Technical Error" in timetable_response.text:
+            raise VtopTimetableError("Technical error while fetching timetable")
 
         # Parse the response
         parsed_data = timetable_parser.parse_time_table(timetable_response.text)
+        if all(not getattr(parsed_data, day) for day in parsed_data.__fields__):
+            raise VtopTimetableError("Timetable not available")
         return parsed_data
 
     except VtopParsingError as e:

--- a/vitap_vtop_client/utils/__init__.py
+++ b/vitap_vtop_client/utils/__init__.py
@@ -2,3 +2,6 @@ from .solve_captcha import solve_captcha
 from .find_csrf import find_csrf
 from .find_login_response import login_error_identifier
 from .extract_student_pfp import extract_pfp_base64
+from .fetch_current_semester import fetch_current_sem_sub_id
+from .sem_sub_id_helpers import get_semester_name
+

--- a/vitap_vtop_client/utils/fetch_current_semester.py
+++ b/vitap_vtop_client/utils/fetch_current_semester.py
@@ -1,0 +1,30 @@
+import time
+import httpx
+from vitap_vtop_client.constants import MARKS_URL, HEADERS
+from vitap_vtop_client.utils.find_current_semester import find_current_sem_sub_id
+from vitap_vtop_client.exceptions.exception import VtopConnectionError, VtopSessionError
+
+
+async def fetch_current_sem_sub_id(
+    client: httpx.AsyncClient,
+    registration_number: str,
+    csrf_token: str,
+) -> str:
+    """Retrieve the current semesterSubId using the marks page."""
+    try:
+        init_data = {
+            "verifyMenu": "true",
+            "authorizedID": registration_number,
+            "_csrf": csrf_token,
+            "nocache": int(round(time.time() * 1000)),
+        }
+        response = await client.post(MARKS_URL, data=init_data, headers=HEADERS)
+        response.raise_for_status()
+        sem = find_current_sem_sub_id(response.text)
+        if not sem:
+            raise VtopSessionError("Unable to determine current semester")
+        return sem
+    except httpx.RequestError as e:
+        raise VtopConnectionError(
+            f"Failed to determine current semester: {e}", original_exception=e, status_code=502
+        )

--- a/vitap_vtop_client/utils/find_current_semester.py
+++ b/vitap_vtop_client/utils/find_current_semester.py
@@ -1,0 +1,25 @@
+from bs4 import BeautifulSoup
+
+
+def find_current_sem_sub_id(html: str) -> str | None:
+    """Parse semesterSubId from a page containing a semester select."""
+    soup = BeautifulSoup(html, 'html.parser')
+
+    select = soup.find('select', attrs={"name": "semesterSubId"})
+    if select:
+        option = select.find("option", selected=True)
+        if option and option.get("value"):
+            value = option["value"].strip()
+            if value:
+                return value
+
+        for opt in select.find_all("option"):
+            value = opt.get("value", "").strip()
+            if value:
+                return value
+
+    input_el = soup.find('input', attrs={'name': 'semesterSubId'})
+    if input_el and input_el.get('value'):
+        return input_el['value']
+    return None
+

--- a/vitap_vtop_client/utils/sem_sub_id_helpers.py
+++ b/vitap_vtop_client/utils/sem_sub_id_helpers.py
@@ -1,0 +1,9 @@
+from vitap_vtop_client.constants import SemSubID
+
+
+def get_semester_name(sem_sub_id: str) -> str | None:
+    """Return the human readable name for a semesterSubId if known."""
+    for name, value in SemSubID.items():
+        if value == sem_sub_id:
+            return name
+    return None


### PR DESCRIPTION
## Summary
- detect the active semester when fetching the timetable
- print timetables in a simple day-wise layout from the CLI
- handle error responses from timetable requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m vitap_vtop_client --help | head -n 20`
- `python -m vitap_vtop_client 24BES7016 current_semester --password wrong | head -n 20` *(fails: invalid credentials)*
- `python -m vitap_vtop_client 24BES7016 timetable --password Vitpassword@1 | head -n 20` *(fails: Not authorized to access timetable page)*

------
https://chatgpt.com/codex/tasks/task_e_68626d0f88f4832fbaff240b34de9248