### PR TITLE
Include timetable info in profile output

### DIFF
--- a/vitap_vtop_client/__main__.py
+++ b/vitap_vtop_client/__main__.py
@@ -48,7 +48,7 @@ async def main():
 
     async with VtopClient(args.registration_number, password) as client:
         if args.command == "profile":
-            data = await client.get_profile()
+            data = await client.get_profile(include_timetables=True)
         elif args.command == "attendance":
             if not args.sem_sub_id:
                 parser.error("attendance command requires --sem")

--- a/vitap_vtop_client/client.py
+++ b/vitap_vtop_client/client.py
@@ -266,7 +266,7 @@ class VtopClient:
             csrf_token=logged_in_info.post_login_csrf_token,
         )
 
-    async def get_profile(self) -> StudentProfileModel:
+    async def get_profile(self, include_timetables: bool = False) -> StudentProfileModel:
         """
         Fetches profile data for the given registration_number.
 
@@ -278,6 +278,7 @@ class VtopClient:
             client=self._client,
             registration_number=logged_in_info.registration_number,
             csrf_token=logged_in_info.post_login_csrf_token,
+            include_timetables=include_timetables,
         )
 
     async def get_exam_schedule(self, sem_sub_id: str) -> ExamScheduleModel:

--- a/vitap_vtop_client/parsers/profile_parser.py
+++ b/vitap_vtop_client/parsers/profile_parser.py
@@ -22,6 +22,7 @@ def parse_student_profile(html: str) -> StudentProfileModel :
 
         profile_data = {
             "base64_pfp": extract_pfp_base64(html),
+            "headings": [h.get_text(strip=True) for h in soup.find_all(["h1", "h2", "h3", "h4", "h5", "h6"])],
         }
 
         for i in range(len(user_data)):
@@ -39,7 +40,7 @@ def parse_student_profile(html: str) -> StudentProfileModel :
             elif text == "EMAIL":
                 profile_data["email"] = user_data[i+1].get_text().strip()
 
-        return StudentProfileModel(**profile_data, grade_history=None,mentor_details=None)
+        return StudentProfileModel(**profile_data, grade_history=None, mentor_details=None)
 
     except Exception as e:
         raise VtopParsingError(f"Failed to parse biometric data: {e}")

--- a/vitap_vtop_client/profile/model/profile_model.py
+++ b/vitap_vtop_client/profile/model/profile_model.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, Dict, List
+
+from vitap_vtop_client.timetable.model import TimetableModel
 
 from vitap_vtop_client.grade_history import GradeHistoryModel
 from vitap_vtop_client.mentor import MentorModel
@@ -15,3 +17,5 @@ class StudentProfileModel(BaseModel):
     base64_pfp: Optional[str]
     grade_history: Optional[GradeHistoryModel]
     mentor_details: Optional[MentorModel]
+    timetables: Optional[Dict[str, TimetableModel]] = None
+    headings: Optional[List[str]] = None


### PR DESCRIPTION
## Summary
- enhance profile model to include timetables and headings
- parse headings from the profile page
- allow fetching profile with timetable data
- CLI profile command now fetches timetables

## Testing
- `python -m vitap_vtop_client 24BES7016 profile --password Vitpassword@1`

------
https://chatgpt.com/codex/tasks/task_e_68627b22932c832faeca24b6759e9576