### PR TITLE
Implement academic headings fetching

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -187,18 +187,24 @@ Fetches details of the student's assigned mentor.
 #### `get_profile()`
 Fetches the complete student profile, including personal details, mentor information, and grade history.
 
+-   **Parameters:**
+    -   `include_timetables` (bool, optional): Fetch timetables for all semesters.
+    -   `include_academic_headings` (bool, optional): Include headings under the "ACADEMICS" menu.
 -   **Returns:** `StudentProfileModel` - An object containing comprehensive student profile data.
 -   **Raises:** `VtopLoginError`, `VtopSessionError`, `VtopConnectionError`, `VtopParsingError`, `VtopProfileError`.
 -   **Example:**
     ```python
     # ... inside async with VtopClient ...
-    profile = await client.get_profile()
+    profile = await client.get_profile(include_academic_headings=True)
     print(f"Name: {profile.student_name}")
     print(f"Email: {profile.email}")
     if profile.mentor_details:
         print(f"Mentor: {profile.mentor_details.faculty_name}")
     if profile.grade_history:
         print(f"CGPA: {profile.grade_history.cgpa}")
+    if profile.academic_headings:
+        for item in profile.academic_headings:
+            print(item)
     # Access profile.base64_pfp for the profile picture
     ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This library is designed as a backend component for applications needing VTOP da
 *   **User Authentication:** Secure login and session management.
 *   **Profile Information:** Retrieve comprehensive student profile details.
 *   **Academic Data:** Access attendance records, timetables, marks, and exam schedules.
+*   **Academic Menu Headings:** Retrieve available links listed under the "ACADEMICS" menu.
 *   **Biometric Logs:** Fetch student biometric entry/exit logs.
 *   **Contact Details:** View mentor, HOD, and Dean information.
 *   **Financial Information:** Check pending payments and download receipts.

--- a/vitap_vtop_client/__main__.py
+++ b/vitap_vtop_client/__main__.py
@@ -48,7 +48,10 @@ async def main():
 
     async with VtopClient(args.registration_number, password) as client:
         if args.command == "profile":
-            data = await client.get_profile(include_timetables=True)
+            data = await client.get_profile(
+                include_timetables=True,
+                include_academic_headings=True,
+            )
         elif args.command == "attendance":
             if not args.sem_sub_id:
                 parser.error("attendance command requires --sem")

--- a/vitap_vtop_client/academic_headings/__init__.py
+++ b/vitap_vtop_client/academic_headings/__init__.py
@@ -1,0 +1,1 @@
+from .academic_headings import fetch_academic_headings

--- a/vitap_vtop_client/academic_headings/academic_headings.py
+++ b/vitap_vtop_client/academic_headings/academic_headings.py
@@ -1,0 +1,30 @@
+import httpx
+from bs4 import BeautifulSoup
+
+from vitap_vtop_client.constants import VTOP_CONTENT_URL, HEADERS
+from vitap_vtop_client.exceptions import VtopConnectionError, VtopParsingError
+
+
+async def fetch_academic_headings(client: httpx.AsyncClient) -> list[str]:
+    """Fetch sub-headings listed under the ``ACADEMICS`` menu on the VTOP content page."""
+    try:
+        response = await client.get(VTOP_CONTENT_URL, headers=HEADERS)
+        response.raise_for_status()
+    except httpx.RequestError as e:
+        raise VtopConnectionError(
+            f"Failed to load VTOP content page: {e}",
+            original_exception=e,
+            status_code=502,
+        )
+
+    try:
+        soup = BeautifulSoup(response.text, "html.parser")
+        academics_tag = soup.find(lambda tag: tag.get_text(strip=True).upper() == "ACADEMICS")
+        if not academics_tag:
+            return []
+        menu = academics_tag.find_next("ul")
+        if not menu:
+            return []
+        return [li.get_text(strip=True) for li in menu.find_all("li")]
+    except Exception as e:
+        raise VtopParsingError(f"Failed to parse academic headings: {e}") from e

--- a/vitap_vtop_client/client.py
+++ b/vitap_vtop_client/client.py
@@ -266,7 +266,11 @@ class VtopClient:
             csrf_token=logged_in_info.post_login_csrf_token,
         )
 
-    async def get_profile(self, include_timetables: bool = False) -> StudentProfileModel:
+    async def get_profile(
+        self,
+        include_timetables: bool = False,
+        include_academic_headings: bool = False,
+    ) -> StudentProfileModel:
         """
         Fetches profile data for the given registration_number.
 
@@ -279,6 +283,7 @@ class VtopClient:
             registration_number=logged_in_info.registration_number,
             csrf_token=logged_in_info.post_login_csrf_token,
             include_timetables=include_timetables,
+            include_academic_headings=include_academic_headings,
         )
 
     async def get_exam_schedule(self, sem_sub_id: str) -> ExamScheduleModel:

--- a/vitap_vtop_client/profile/model/profile_model.py
+++ b/vitap_vtop_client/profile/model/profile_model.py
@@ -19,3 +19,4 @@ class StudentProfileModel(BaseModel):
     mentor_details: Optional[MentorModel]
     timetables: Optional[Dict[str, TimetableModel]] = None
     headings: Optional[List[str]] = None
+    academic_headings: Optional[List[str]] = None

--- a/vitap_vtop_client/profile/profile.py
+++ b/vitap_vtop_client/profile/profile.py
@@ -7,6 +7,7 @@ from vitap_vtop_client.grade_history import fetch_grade_history
 from vitap_vtop_client.parsers.profile_parser import parse_student_profile
 from .model import StudentProfileModel
 from vitap_vtop_client.timetable import fetch_timetable
+from vitap_vtop_client.academic_headings import fetch_academic_headings
 
 from vitap_vtop_client.exceptions import VtopConnectionError, VtopProfileError, VtopParsingError
 
@@ -15,6 +16,7 @@ async def fetch_profile(
     registration_number: str,
     csrf_token: str,
     include_timetables: bool = False,
+    include_academic_headings: bool = False,
 ) -> StudentProfileModel:
     """
     Retrieves and compiles the student profile information from the VTOP Portal.
@@ -24,11 +26,14 @@ async def fetch_profile(
         registration_number (str): The student's username.
         csrf_token (str): CSRF token for authentication.
         include_timetables (bool): When True, fetches timetable for all semesters.
+        include_academic_headings (bool): When True, fetches headings under the "ACADEMICS" menu.
 
     Returns:
         StudentProfileModel: The student's profile information. If
         include_timetables is True, the profile will include timetable
-        information for all semesters available in ``SemSubID``.
+        information for all semesters available in ``SemSubID``. If
+        ``include_academic_headings`` is True, ``academic_headings`` will
+        contain the list of headings from the Academics menu.
 
     Raises:
         VtopConnectionError: If an HTTP request fails.
@@ -69,6 +74,9 @@ async def fetch_profile(
                     profile.timetables[name] = await task
                 except Exception:
                     profile.timetables[name] = None
+
+        if include_timetables or include_academic_headings:
+            profile.academic_headings = await fetch_academic_headings(client)
 
         return profile
 


### PR DESCRIPTION
## Summary
- parse VTOP academic menu headings
- expose headings via StudentProfileModel
- allow `get_profile()` to return the new data
- show academic headings in CLI profile command
- document new feature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686283c50c3c832fa4acec95e18a7149