### PR TITLE
Add visible marks output

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -187,6 +187,11 @@ Fetches details of the student's assigned mentor.
 #### `get_profile()`
 Fetches the complete student profile, including personal details, mentor information, and grade history.
 
+If called via the CLI with the `profile` command, the library also retrieves
+marks for the specified semester (defaulting to **FALL SEM 2024-25** if none is
+provided via `--sem`). These marks are attached to the returned
+`StudentProfileModel` under the `marks` attribute.
+
 -   **Returns:** `StudentProfileModel` - An object containing comprehensive student profile data.
 -   **Raises:** `VtopLoginError`, `VtopSessionError`, `VtopConnectionError`, `VtopParsingError`, `VtopProfileError`.
 -   **Example:**
@@ -222,6 +227,11 @@ Fetches all the available exam schedules for the specified semester.
 
 #### `get_marks(sem_sub_id: str)`
 Fetches available marks for the specified semester.
+
+Before the marks can be retrieved, the library now performs two additional
+requests to the **Student Time Table** page to set the desired semester
+context. This mimics the manual workflow on VTOP where a user selects the
+semester in the timetable section prior to viewing marks.
 
 -   **Parameters:**
     -   `sem_sub_id` (str): The semester ID. See [Semester IDs](#semester-ids-sem_sub_id).
@@ -288,7 +298,7 @@ Refer to the model definitions in:
 
 -   [`vitap_vtop_client/mentor/model/mentor_model.py`](vitap_vtop_client/mentor/model/mentor_model.py) for `MentorModel`
 
--   [`vitap_vtop_client/profile/model/profile_model.py`](vitap_vtop_client/profile/model/profile_model.py) for `StudentProfileModel`
+-   [`vitap_vtop_client/profile/model/profile_model.py`](vitap_vtop_client/profile/model/profile_model.py) for `StudentProfileModel` (includes a `marks` field)
 
 -   [`vitap_vtop_client/login/model/login_model.py`](vitap_vtop_client/login/model/login_model.py) for `LoggedInStudent`
 

--- a/vitap_vtop_client/__main__.py
+++ b/vitap_vtop_client/__main__.py
@@ -5,6 +5,7 @@ from getpass import getpass
 from typing import Any
 
 from .client import VtopClient
+from .constants import SemSubID
 
 
 def _shorten(value: str, max_length: int = 40) -> str:
@@ -17,10 +18,16 @@ def _shorten(value: str, max_length: int = 40) -> str:
 def _print_lines(obj: Any, indent: int = 0) -> None:
     """Recursively print dictionaries/lists with each entry on its own line."""
     prefix = " " * indent
-    if hasattr(obj, "dict"):
+
+    if hasattr(obj, "model_dump"):
+        obj = obj.model_dump(exclude_none=True)
+    elif hasattr(obj, "dict"):
         obj = obj.dict(exclude_none=True)
 
     if isinstance(obj, dict):
+        if list(obj.keys()) == ["root"]:
+            _print_lines(obj["root"], indent)
+            return
         for key, value in obj.items():
             if isinstance(value, (dict, list)):
                 print(f"{prefix}{key}:")
@@ -49,6 +56,11 @@ async def main():
     async with VtopClient(args.registration_number, password) as client:
         if args.command == "profile":
             data = await client.get_profile(include_timetables=True)
+            sem_id = args.sem_sub_id or SemSubID.get("FALL SEM 2024-25")
+            try:
+                data.marks = await client.get_marks(sem_id)
+            except Exception as e:
+                print(f"Failed to fetch marks: {e}")
         elif args.command == "attendance":
             if not args.sem_sub_id:
                 parser.error("attendance command requires --sem")
@@ -70,6 +82,13 @@ async def main():
 
  
         _print_lines(data)
+
+        if args.command == "profile":
+            if data.marks is None:
+                print("Marks: not retrieved")
+            elif hasattr(data.marks, "root") and not data.marks.root:
+                print("Marks: []")
+
  
 
 if __name__ == "__main__":

--- a/vitap_vtop_client/marks/marks.py
+++ b/vitap_vtop_client/marks/marks.py
@@ -2,7 +2,13 @@ from datetime import datetime, timezone
 import time
 import httpx
 from typing import Union
-from vitap_vtop_client.constants import MARKS_URL, VIEW_MARKS_URL, HEADERS
+from vitap_vtop_client.constants import (
+    MARKS_URL,
+    VIEW_MARKS_URL,
+    TIME_TABLE_URL,
+    GET_TIME_TABLE_URL,
+    HEADERS,
+)
 from vitap_vtop_client.marks.model.marks_model import MarksModel
 from vitap_vtop_client.parsers.marks_parser import parse_marks
 from vitap_vtop_client.exceptions.exception import (
@@ -35,6 +41,23 @@ async def fetch_marks(
         VtopAttendanceError: If unexpected or parsing errors occur.
     """
     try:
+        # Initialize timetable view to set semester context
+        init_tt_data = {
+            "verifyMenu": "true",
+            "authorizedID": registration_number,
+            "_csrf": csrf_token,
+            "nocache": int(round(time.time() * 1000)),
+        }
+        await client.post(TIME_TABLE_URL, data=init_tt_data, headers=HEADERS)
+
+        select_sem_data = {
+            "_csrf": csrf_token,
+            "semesterSubId": semSubID,
+            "authorizedID": registration_number,
+            "x": datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT"),
+        }
+        await client.post(GET_TIME_TABLE_URL, data=select_sem_data, headers=HEADERS)
+
         init_data = {
             "verifyMenu": "true",
             "authorizedID": registration_number,

--- a/vitap_vtop_client/marks/model/__init__.py
+++ b/vitap_vtop_client/marks/model/__init__.py
@@ -1,0 +1,5 @@
+"""Public exports for marks-related models."""
+
+from .marks_model import MarkDetail, SubjectMark, MarksModel
+
+__all__ = ["MarkDetail", "SubjectMark", "MarksModel"]

--- a/vitap_vtop_client/profile/model/profile_model.py
+++ b/vitap_vtop_client/profile/model/profile_model.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel
 from typing import Optional, Dict, List
 
+from vitap_vtop_client.marks.model import MarksModel
+
 from vitap_vtop_client.timetable.model import TimetableModel
 
 from vitap_vtop_client.grade_history import GradeHistoryModel
@@ -19,3 +21,4 @@ class StudentProfileModel(BaseModel):
     mentor_details: Optional[MentorModel]
     timetables: Optional[Dict[str, TimetableModel]] = None
     headings: Optional[List[str]] = None
+    marks: Optional[MarksModel] = None


### PR DESCRIPTION
## Summary
- fix CLI printing of root models
- show message if no marks are returned

## Testing
- `pytest -q`
- `python -m vitap_vtop_client 24BES7016 profile --password Vitpassword@1 | tail -n 30`

------
https://chatgpt.com/codex/tasks/task_e_68628f5235a4832f8fa4cbc782c0cb63