### PR TITLE
Add visible attendance output

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -121,6 +121,13 @@ Fetches attendance data for the specified semester.
         print(f"Course: {course_attendance.course_name}, Percentage: {course_attendance.attendance_percentage}%")
     ```
 
+#### `get_all_attendance()`
+Fetches attendance for all semesters defined in `SemSubID`.
+
+-   **Returns:** `dict[str, list[AttendanceModel]]` - Attendance mapped by semester name.
+
+This method is primarily used by the CLI when the `profile` command is invoked without `--sem`.
+
 #### `get_biometric(date: str)`
 Fetches biometric (entry/exit) logs for a specific date.
 
@@ -187,6 +194,16 @@ Fetches details of the student's assigned mentor.
 #### `get_profile()`
 Fetches the complete student profile, including personal details, mentor information, and grade history.
 
+If called via the CLI with the `profile` command, the library now retrieves
+marks for **all** semesters when no `--sem` argument is supplied. When
+`--sem` is provided, only that specific semester's marks are fetched.
+The resulting marks are attached to the returned `StudentProfileModel` under a
+`marks` dictionary where each key is the semester name.
+Attendance retrieval follows the same logic: when invoked from the CLI without
+`--sem`, attendance for all semesters is fetched and stored in an `attendance`
+dictionary on the profile model. If `--sem` is specified, only that semester's
+attendance is retrieved.
+
 -   **Returns:** `StudentProfileModel` - An object containing comprehensive student profile data.
 -   **Raises:** `VtopLoginError`, `VtopSessionError`, `VtopConnectionError`, `VtopParsingError`, `VtopProfileError`.
 -   **Example:**
@@ -222,6 +239,11 @@ Fetches all the available exam schedules for the specified semester.
 
 #### `get_marks(sem_sub_id: str)`
 Fetches available marks for the specified semester.
+
+Before the marks can be retrieved, the library now performs two additional
+requests to the **Student Time Table** page to set the desired semester
+context. This mimics the manual workflow on VTOP where a user selects the
+semester in the timetable section prior to viewing marks.
 
 -   **Parameters:**
     -   `sem_sub_id` (str): The semester ID. See [Semester IDs](#semester-ids-sem_sub_id).
@@ -288,7 +310,7 @@ Refer to the model definitions in:
 
 -   [`vitap_vtop_client/mentor/model/mentor_model.py`](vitap_vtop_client/mentor/model/mentor_model.py) for `MentorModel`
 
--   [`vitap_vtop_client/profile/model/profile_model.py`](vitap_vtop_client/profile/model/profile_model.py) for `StudentProfileModel`
+-   [`vitap_vtop_client/profile/model/profile_model.py`](vitap_vtop_client/profile/model/profile_model.py) for `StudentProfileModel` (includes `marks` and `attendance` dictionaries)
 
 -   [`vitap_vtop_client/login/model/login_model.py`](vitap_vtop_client/login/model/login_model.py) for `LoggedInStudent`
 

--- a/vitap_vtop_client/__main__.py
+++ b/vitap_vtop_client/__main__.py
@@ -1,10 +1,11 @@
 import asyncio
 import argparse
 from getpass import getpass
- 
+
 from typing import Any
 
 from .client import VtopClient
+from .constants import SemSubID
 
 
 def _shorten(value: str, max_length: int = 40) -> str:
@@ -17,10 +18,16 @@ def _shorten(value: str, max_length: int = 40) -> str:
 def _print_lines(obj: Any, indent: int = 0) -> None:
     """Recursively print dictionaries/lists with each entry on its own line."""
     prefix = " " * indent
-    if hasattr(obj, "dict"):
+
+    if hasattr(obj, "model_dump"):
+        obj = obj.model_dump(exclude_none=True)
+    elif hasattr(obj, "dict"):
         obj = obj.dict(exclude_none=True)
 
     if isinstance(obj, dict):
+        if list(obj.keys()) == ["root"]:
+            _print_lines(obj["root"], indent)
+            return
         for key, value in obj.items():
             if isinstance(value, (dict, list)):
                 print(f"{prefix}{key}:")
@@ -34,14 +41,36 @@ def _print_lines(obj: Any, indent: int = 0) -> None:
             _print_lines(item, indent)
     else:
         print(f"{prefix}{obj}")
- 
+
+
 async def main():
-    parser = argparse.ArgumentParser(description="Command line interface for vitap_vtop_client")
+    parser = argparse.ArgumentParser(
+        description="Command line interface for vitap_vtop_client"
+    )
     parser.add_argument("registration_number", help="Your VTOP registration number")
-    parser.add_argument("command", choices=["profile", "attendance", "timetable", "biometric", "grade_history", "mentor"], help="Which information to fetch")
-    parser.add_argument("--password", dest="password", help="VTOP password (will prompt if omitted)")
-    parser.add_argument("--sem", dest="sem_sub_id", help="Semester subject ID for semester specific commands")
-    parser.add_argument("--date", dest="date", help="Date for biometric in dd/mm/yyyy format")
+    parser.add_argument(
+        "command",
+        choices=[
+            "profile",
+            "attendance",
+            "timetable",
+            "biometric",
+            "grade_history",
+            "mentor",
+        ],
+        help="Which information to fetch",
+    )
+    parser.add_argument(
+        "--password", dest="password", help="VTOP password (will prompt if omitted)"
+    )
+    parser.add_argument(
+        "--sem",
+        dest="sem_sub_id",
+        help="Semester subject ID for semester specific commands",
+    )
+    parser.add_argument(
+        "--date", dest="date", help="Date for biometric in dd/mm/yyyy format"
+    )
     args = parser.parse_args()
 
     password = args.password or getpass("Password: ")
@@ -49,6 +78,19 @@ async def main():
     async with VtopClient(args.registration_number, password) as client:
         if args.command == "profile":
             data = await client.get_profile(include_timetables=True)
+            try:
+                if args.sem_sub_id:
+                    data.marks = {
+                        args.sem_sub_id: await client.get_marks(args.sem_sub_id)
+                    }
+                    data.attendance = {
+                        args.sem_sub_id: await client.get_attendance(args.sem_sub_id)
+                    }
+                else:
+                    data.marks = await client.get_all_marks()
+                    data.attendance = await client.get_all_attendance()
+            except Exception as e:
+                print(f"Failed to fetch marks/attendance: {e}")
         elif args.command == "attendance":
             if not args.sem_sub_id:
                 parser.error("attendance command requires --sem")
@@ -68,9 +110,18 @@ async def main():
         else:
             parser.error("Unknown command")
 
- 
         _print_lines(data)
- 
+
+        if args.command == "profile":
+            if data.marks is None:
+                print("Marks: not retrieved")
+            elif isinstance(data.marks, dict) and not data.marks:
+                print("Marks: {}")
+            if data.attendance is None:
+                print("Attendance: not retrieved")
+            elif isinstance(data.attendance, dict) and not data.attendance:
+                print("Attendance: {}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/vitap_vtop_client/attendance/model/__init__.py
+++ b/vitap_vtop_client/attendance/model/__init__.py
@@ -1,1 +1,5 @@
+"""Public exports for attendance related models."""
+
 from .attendance_model import AttendanceModel
+
+__all__ = ["AttendanceModel"]

--- a/vitap_vtop_client/client.py
+++ b/vitap_vtop_client/client.py
@@ -2,7 +2,7 @@ from typing import List
 import httpx
 import asyncio
 
-from .constants import VTOP_BASE_URL
+from .constants import VTOP_BASE_URL, SemSubID
 
 from .exceptions import (
     VtopLoginError,
@@ -266,7 +266,9 @@ class VtopClient:
             csrf_token=logged_in_info.post_login_csrf_token,
         )
 
-    async def get_profile(self, include_timetables: bool = False) -> StudentProfileModel:
+    async def get_profile(
+        self, include_timetables: bool = False
+    ) -> StudentProfileModel:
         """
         Fetches profile data for the given registration_number.
 
@@ -310,6 +312,50 @@ class VtopClient:
             csrf_token=logged_in_info.post_login_csrf_token,
             semSubID=sem_sub_id,
         )
+
+    async def get_all_marks(self) -> dict[str, MarksModel]:
+        """Fetch marks for all semesters defined in ``SemSubID``."""
+        logged_in_info = await self._ensure_logged_in()
+        tasks = {
+            name: asyncio.create_task(
+                fetch_marks(
+                    client=self._client,
+                    registration_number=logged_in_info.registration_number,
+                    csrf_token=logged_in_info.post_login_csrf_token,
+                    semSubID=sem_id,
+                )
+            )
+            for name, sem_id in SemSubID.items()
+        }
+        results: dict[str, MarksModel] = {}
+        for name, task in tasks.items():
+            try:
+                results[name] = await task
+            except Exception:
+                results[name] = MarksModel(root=[])
+        return results
+
+    async def get_all_attendance(self) -> dict[str, list[AttendanceModel]]:
+        """Fetch attendance for all semesters defined in ``SemSubID``."""
+        logged_in_info = await self._ensure_logged_in()
+        tasks = {
+            name: asyncio.create_task(
+                fetch_attendance(
+                    client=self._client,
+                    registration_number=logged_in_info.registration_number,
+                    csrf_token=logged_in_info.post_login_csrf_token,
+                    semSubID=sem_id,
+                )
+            )
+            for name, sem_id in SemSubID.items()
+        }
+        results: dict[str, list[AttendanceModel]] = {}
+        for name, task in tasks.items():
+            try:
+                results[name] = await task
+            except Exception:
+                results[name] = []
+        return results
 
     async def get_weekend_outing_requests(self) -> WeekendOutingModel:
         """

--- a/vitap_vtop_client/marks/marks.py
+++ b/vitap_vtop_client/marks/marks.py
@@ -2,7 +2,13 @@ from datetime import datetime, timezone
 import time
 import httpx
 from typing import Union
-from vitap_vtop_client.constants import MARKS_URL, VIEW_MARKS_URL, HEADERS
+from vitap_vtop_client.constants import (
+    MARKS_URL,
+    VIEW_MARKS_URL,
+    TIME_TABLE_URL,
+    GET_TIME_TABLE_URL,
+    HEADERS,
+)
 from vitap_vtop_client.marks.model.marks_model import MarksModel
 from vitap_vtop_client.parsers.marks_parser import parse_marks
 from vitap_vtop_client.exceptions.exception import (
@@ -35,6 +41,23 @@ async def fetch_marks(
         VtopAttendanceError: If unexpected or parsing errors occur.
     """
     try:
+        # Initialize timetable view to set semester context
+        init_tt_data = {
+            "verifyMenu": "true",
+            "authorizedID": registration_number,
+            "_csrf": csrf_token,
+            "nocache": int(round(time.time() * 1000)),
+        }
+        await client.post(TIME_TABLE_URL, data=init_tt_data, headers=HEADERS)
+
+        select_sem_data = {
+            "_csrf": csrf_token,
+            "semesterSubId": semSubID,
+            "authorizedID": registration_number,
+            "x": datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S GMT"),
+        }
+        await client.post(GET_TIME_TABLE_URL, data=select_sem_data, headers=HEADERS)
+
         init_data = {
             "verifyMenu": "true",
             "authorizedID": registration_number,

--- a/vitap_vtop_client/marks/model/__init__.py
+++ b/vitap_vtop_client/marks/model/__init__.py
@@ -1,0 +1,5 @@
+"""Public exports for marks-related models."""
+
+from .marks_model import MarkDetail, SubjectMark, MarksModel
+
+__all__ = ["MarkDetail", "SubjectMark", "MarksModel"]

--- a/vitap_vtop_client/profile/model/profile_model.py
+++ b/vitap_vtop_client/profile/model/profile_model.py
@@ -1,6 +1,9 @@
 from pydantic import BaseModel
 from typing import Optional, Dict, List
 
+from vitap_vtop_client.marks.model import MarksModel
+from vitap_vtop_client.attendance.model import AttendanceModel
+
 from vitap_vtop_client.timetable.model import TimetableModel
 
 from vitap_vtop_client.grade_history import GradeHistoryModel
@@ -19,3 +22,5 @@ class StudentProfileModel(BaseModel):
     mentor_details: Optional[MentorModel]
     timetables: Optional[Dict[str, TimetableModel]] = None
     headings: Optional[List[str]] = None
+    marks: Optional[Dict[str, MarksModel]] = None
+    attendance: Optional[Dict[str, List[AttendanceModel]]] = None


### PR DESCRIPTION
## Summary
- show attendance in CLI profile output
- expose attendance model and attach attendance data to student profile
- fetch attendance for all semesters when no `--sem` given
- document the new attendance support

## Testing
- `pytest -q`
- `python -m vitap_vtop_client 24BES7016 profile --password Vitpassword@1 --sem AP2024252 | head -n 20` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68628f5235a4832f8fa4cbc782c0cb63