### PR TITLE
Expand Java client skeleton

### DIFF
--- a/java_client/README.md
+++ b/java_client/README.md
@@ -1,0 +1,40 @@
+# VITAP VTOP Client (Java)
+
+This module provides a Java-based client for interacting with the VITAP VTOP portal. It mirrors the functionality of the existing Python library but is implemented using Java's `HttpClient` and basic object models.
+
+The code mirrors the high level API of the Python version.  Each feature from the
+Python client has a corresponding service class in Java.  The current
+implementation only returns placeholder data but lays out the structure for:
+
+* Login and session management
+* Attendance and biometric logs
+* Timetable and exam schedules
+* Marks and grade history
+* Mentor information and profile data
+* Outing requests and payment info
+
+This is still a simplified implementation and the HTTP calls need to be filled
+in, but all entry points are available via `VtopClient`.
+
+## Building
+
+The project uses Maven for dependency management.
+
+```bash
+mvn package
+```
+
+## Usage Example
+
+```java
+VtopClient client = new VtopClient("YOUR_REG_NO", "YOUR_PASSWORD");
+try {
+    client.login();
+    var attendance = client.getAttendance("AP2024252");
+    System.out.println(attendance);
+} finally {
+    client.close();
+}
+```
+
+See `VtopClient` for available methods.

--- a/java_client/pom.xml
+++ b/java_client/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.vitap</groupId>
+    <artifactId>vtop-client</artifactId>
+    <version>0.1.0</version>
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <!-- JSON parsing -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/java_client/src/main/java/com/vitap/vtopclient/VtopClient.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/VtopClient.java
@@ -1,0 +1,174 @@
+package com.vitap.vtopclient;
+
+import com.vitap.vtopclient.login.LoginService;
+import com.vitap.vtopclient.model.LoggedInStudent;
+import com.vitap.vtopclient.attendance.AttendanceService;
+import com.vitap.vtopclient.biometric.BiometricService;
+import com.vitap.vtopclient.examschedule.ExamScheduleService;
+import com.vitap.vtopclient.marks.MarksService;
+import com.vitap.vtopclient.mentor.MentorService;
+import com.vitap.vtopclient.profile.ProfileService;
+import com.vitap.vtopclient.timetable.TimetableService;
+import com.vitap.vtopclient.gradehistory.GradeHistoryService;
+import com.vitap.vtopclient.outing.OutingService;
+import com.vitap.vtopclient.payments.PaymentService;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Simplified Java version of the Python VtopClient.
+ * Only a few methods are implemented as an example.
+ */
+public class VtopClient implements Closeable {
+    private final String registrationNumber;
+    private final String password;
+    private LoggedInStudent loggedInStudent;
+    private final LoginService loginService = new LoginService();
+
+    // Services replicating Python modules
+    private final AttendanceService attendanceService = new AttendanceService();
+    private final BiometricService biometricService = new BiometricService();
+    private final TimetableService timetableService = new TimetableService();
+    private final GradeHistoryService gradeHistoryService = new GradeHistoryService();
+    private final MentorService mentorService = new MentorService();
+    private final ProfileService profileService = new ProfileService();
+    private final ExamScheduleService examScheduleService = new ExamScheduleService();
+    private final MarksService marksService = new MarksService();
+    private final OutingService outingService = new OutingService();
+    private final PaymentService paymentService = new PaymentService();
+
+    public VtopClient(String registrationNumber, String password) {
+        this.registrationNumber = registrationNumber;
+        this.password = password;
+    }
+
+    /** Perform login and store session info */
+    public void login() throws IOException, InterruptedException {
+        loggedInStudent = loginService.login(registrationNumber, password);
+    }
+
+    public boolean isLoggedIn() {
+        return loggedInStudent != null;
+    }
+
+    /** Fetch attendance */
+    public String getAttendance(String semSubId) throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return attendanceService.fetchAttendance(
+                loggedInStudent.getRegistrationNumber(),
+                semSubId,
+                loggedInStudent.getCsrfToken());
+    }
+
+    /** Fetch profile */
+    public String getProfile() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return profileService.fetchProfile(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getBiometric(String date) throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return biometricService.fetchBiometric(
+                loggedInStudent.getRegistrationNumber(),
+                date,
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getTimetable(String semSubId) throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return timetableService.fetchTimetable(
+                loggedInStudent.getRegistrationNumber(),
+                semSubId,
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getGradeHistory() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return gradeHistoryService.fetchGradeHistory(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getMentor() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return mentorService.fetchMentor(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getExamSchedule(String semSubId) throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return examScheduleService.fetchExamSchedule(
+                loggedInStudent.getRegistrationNumber(),
+                semSubId,
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getMarks(String semSubId) throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return marksService.fetchMarks(
+                loggedInStudent.getRegistrationNumber(),
+                semSubId,
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getWeekendOutings() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return outingService.fetchWeekendOutings(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getGeneralOutings() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return outingService.fetchGeneralOutings(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getPendingPayments() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return paymentService.fetchPendingPayments(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    public String getPaymentReceipts() throws IOException {
+        if (!isLoggedIn()) {
+            throw new IOException("Not logged in");
+        }
+        return paymentService.fetchPaymentReceipts(
+                loggedInStudent.getRegistrationNumber(),
+                loggedInStudent.getCsrfToken());
+    }
+
+    @Override
+    public void close() throws IOException {
+        // Nothing to close in this simplified version
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/attendance/AttendanceService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/attendance/AttendanceService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.attendance;
+
+public class AttendanceService {
+    public String fetchAttendance(String registrationNumber, String semSubId, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "attendance for " + semSubId;
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/biometric/BiometricService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/biometric/BiometricService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.biometric;
+
+public class BiometricService {
+    public String fetchBiometric(String registrationNumber, String date, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "biometric for " + date;
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/constants/Constants.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/constants/Constants.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.constants;
+
+public final class Constants {
+    public static final String BASE_URL = "https://vtop.vitap.ac.in";
+    public static final String LOGIN_ROUTE = "/vtop/login";
+    public static final String CSRF_ROUTE = "/vtop/open/page";
+    private Constants() {}
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/examschedule/ExamScheduleService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/examschedule/ExamScheduleService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.examschedule;
+
+public class ExamScheduleService {
+    public String fetchExamSchedule(String registrationNumber, String semSubId, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "exam schedule for " + semSubId;
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/gradehistory/GradeHistoryService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/gradehistory/GradeHistoryService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.gradehistory;
+
+public class GradeHistoryService {
+    public String fetchGradeHistory(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "grade history";
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/login/LoginService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/login/LoginService.java
@@ -1,0 +1,43 @@
+package com.vitap.vtopclient.login;
+
+import com.vitap.vtopclient.constants.Constants;
+import com.vitap.vtopclient.model.LoggedInStudent;
+import com.vitap.vtopclient.util.CsrfUtil;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class LoginService {
+    private final HttpClient httpClient = HttpClient.newBuilder().build();
+
+    public LoggedInStudent login(String registrationNumber, String password) throws IOException, InterruptedException {
+        // Step 1: fetch CSRF token
+        HttpRequest csrfReq = HttpRequest.newBuilder()
+                .uri(URI.create(Constants.BASE_URL + Constants.CSRF_ROUTE))
+                .GET()
+                .build();
+        HttpResponse<String> csrfResp = httpClient.send(csrfReq, HttpResponse.BodyHandlers.ofString());
+        String csrf = CsrfUtil.findCsrf(csrfResp.body());
+        if (csrf == null) {
+            throw new IOException("Unable to fetch CSRF token");
+        }
+
+        // Step 2: send login request
+        String form = "_csrf=" + csrf + "&username=" + registrationNumber + "&password=" + password;
+        HttpRequest loginReq = HttpRequest.newBuilder()
+                .uri(URI.create(Constants.BASE_URL + Constants.LOGIN_ROUTE))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build();
+
+        HttpResponse<String> loginResp = httpClient.send(loginReq, HttpResponse.BodyHandlers.ofString());
+        if (loginResp.statusCode() != 200) {
+            throw new IOException("Login failed: status " + loginResp.statusCode());
+        }
+
+        return new LoggedInStudent(registrationNumber, csrf);
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/marks/MarksService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/marks/MarksService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.marks;
+
+public class MarksService {
+    public String fetchMarks(String registrationNumber, String semSubId, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "marks for " + semSubId;
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/mentor/MentorService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/mentor/MentorService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.mentor;
+
+public class MentorService {
+    public String fetchMentor(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "mentor info";
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/model/LoggedInStudent.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/model/LoggedInStudent.java
@@ -1,0 +1,19 @@
+package com.vitap.vtopclient.model;
+
+public class LoggedInStudent {
+    private final String registrationNumber;
+    private final String csrfToken;
+
+    public LoggedInStudent(String registrationNumber, String csrfToken) {
+        this.registrationNumber = registrationNumber;
+        this.csrfToken = csrfToken;
+    }
+
+    public String getRegistrationNumber() {
+        return registrationNumber;
+    }
+
+    public String getCsrfToken() {
+        return csrfToken;
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/outing/OutingService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/outing/OutingService.java
@@ -1,0 +1,12 @@
+package com.vitap.vtopclient.outing;
+
+public class OutingService {
+    public String fetchWeekendOutings(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "weekend outings";
+    }
+    public String fetchGeneralOutings(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "general outings";
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/payments/PaymentService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/payments/PaymentService.java
@@ -1,0 +1,12 @@
+package com.vitap.vtopclient.payments;
+
+public class PaymentService {
+    public String fetchPendingPayments(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "pending payments";
+    }
+    public String fetchPaymentReceipts(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "payment receipts";
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/profile/ProfileService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/profile/ProfileService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.profile;
+
+public class ProfileService {
+    public String fetchProfile(String registrationNumber, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "profile";
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/timetable/TimetableService.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/timetable/TimetableService.java
@@ -1,0 +1,8 @@
+package com.vitap.vtopclient.timetable;
+
+public class TimetableService {
+    public String fetchTimetable(String registrationNumber, String semSubId, String csrfToken) {
+        // TODO: implement HTTP request to VTOP
+        return "timetable for " + semSubId;
+    }
+}

--- a/java_client/src/main/java/com/vitap/vtopclient/util/CsrfUtil.java
+++ b/java_client/src/main/java/com/vitap/vtopclient/util/CsrfUtil.java
@@ -1,0 +1,16 @@
+package com.vitap.vtopclient.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CsrfUtil {
+    private static final Pattern CSRF_PATTERN = Pattern.compile("name=\\"_csrf\\" value=\\"(.*?)\\"");
+
+    public static String findCsrf(String html) {
+        Matcher m = CSRF_PATTERN.matcher(html);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- flesh out `VtopClient` with service classes matching the Python API
- create placeholder service classes for all features (attendance, biometric, timetable, grade history, mentor, profile, exam schedule, marks, outing, payments)
- update Java client README with description of the expanded API

## Testing
- `pytest -q`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b8c89f5c832fb41f5e989b1c4c1e